### PR TITLE
Local artificial branches

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git/
 .github/
+output/
 .DS_Store
 .gitignore
 LICENSE

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'main'
+      - 'local-parser-test'
 
 jobs:
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'local-parser-test'
+      - 'main'
 
 jobs:
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.sql
+output/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ```
-  ______            _   _____                         
- |  ____|          | | |  __ \                        
- | |__ ___  ___  __| | | |__) |_ _ _ __ ___  ___ _ __ 
+  ______            _   _____
+ |  ____|          | | |  __ \
+ | |__ ___  ___  __| | | |__) |_ _ _ __ ___  ___ _ __
  |  __/ _ \/ _ \/ _` | |  ___/ _` | '__/ __|/ _ \ '__|
- | | |  __/  __/ (_| | | |  | (_| | |  \__ \  __/ |   
- |_|  \___|\___|\__,_| |_|   \__,_|_|  |___/\___|_|   
+ | | |  __/  __/ (_| | | |  | (_| | |  \__ \  __/ |
+ |_|  \___|\___|\__,_| |_|   \__,_|_|  |___/\___|_|
 
-```                                                     
+```
 [![Feed Parser Deployment](https://github.com/ministryofjustice/feed-parser/actions/workflows/cd.yaml/badge.svg)](https://github.com/ministryofjustice/feed-parser/actions/workflows/cd.yaml)
 
 # FeedParser
@@ -24,3 +24,14 @@ To check if the image has been pushed into the ECR repo make sure in your termin
 ## Usage
 
 We are currently running this application in [kubernetes using a cron manifest file](https://github.com/ministryofjustice/hale-platform/blob/main/helm_deploy/wordpress/templates/cron-feedparser.yaml) that periodically runs depending on the cron schedule.
+
+## Local development
+
+To run locally:
+
+1. In this repo root directory run `make build`.
+2. Run `make run`
+
+To stop run `make down` .
+
+Files will be exported to the `/output` folder rather then exported to s3.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  feedparser-local:
+    image: feedparser-local
+    volumes:
+      - ./output:/output
+    container_name: feedparser-local
+    environment:
+      - ENV_TYPE=local
+    command: []

--- a/makefile
+++ b/makefile
@@ -6,3 +6,6 @@ run:
 
 down:
 	docker compose down
+
+log:
+	docker logs feedparser-local

--- a/makefile
+++ b/makefile
@@ -1,0 +1,8 @@
+build:
+	docker build -f dockerfile -t feedparser-local .
+
+run:
+	docker compose up -d
+
+down:
+	docker compose down

--- a/run.php
+++ b/run.php
@@ -7,6 +7,32 @@ require 'inc/OleeoFeedParser.php';
 use Aws\S3\S3Client;
 use Aws\Exception\AwsException;
 
+// Check environment
+$envType = getenv('ENV_TYPE');
+
+if ($envType === 'local') {
+    echo 'The environment type is local export files locally.';
+}
+
+if ($envType != 'local') {
+    echo 'The environment type is not local, setup and push to s3.';
+
+     // AWS S3 Bucket Name
+    $s3BucketName = getenv('S3_UPLOADS_BUCKET');
+
+    // AWS S3 Bucket Path
+    $s3BucketPath = 'feed-parser/';  // Set to an empty string if the root of the bucket
+
+    // AWS S3 Region
+    $awsRegion = 'eu-west-2';
+
+    // Create an S3Client with the AWS credentials automatically provided by IAM instance profile
+    $s3Client = new S3Client([
+        'region' => $awsRegion,
+        'version' => 'latest'
+    ]);
+}
+
 echo 'Feed Parser Started';
 
 $feeds = [
@@ -41,27 +67,13 @@ $feeds = [
     ],
  ];
 
-// if (count($feeds) == 0) {
-//     return;
-// }
+if (count($feeds) == 0) {
+    exit;
+}
 
-// $availableFeeds = [];
+$availableFeeds = [];
 
-//  // AWS S3 Bucket Name
-// $s3BucketName = getenv('S3_UPLOADS_BUCKET');
-
-// // AWS S3 Bucket Path
-// $s3BucketPath = 'feed-parser/';  // Set to an empty string if the root of the bucket
-
-// // AWS S3 Region
-// $awsRegion = 'eu-west-2';
-
-// // Create an S3Client with the AWS credentials automatically provided by IAM instance profile
-// $s3Client = new S3Client([
-//     'region' => $awsRegion,
-//     'version' => 'latest'
-// ]);
-
+$uploadResult = [];
 
 foreach ($feeds as $feed) {
     $feedID = $feed['id'];
@@ -101,71 +113,89 @@ foreach ($feeds as $feed) {
         continue;
     }
 
-    #$uploadResult = uploadFiletoS3($s3Client, $s3BucketName, $s3BucketPath . "$feedID.json", $jsonFile);
-
-    $file_path = "output/$feedID.json";
-
-    // Use file_put_contents to save the content to the local file
-    $result = file_put_contents($file_path, $jsonFile);
-
-    // if (!$uploadResult['success'] || empty($uploadResult['fileURL'])) {
-    //     continue;
-    // }
+    if ($envType === 'local') {
+        $uploadResult['fileURL'] = $jsonFile;
+    }
 
     $availableFeeds[] = [
         'name' => $feed['name'],
-        // 'url' => $uploadResult['fileURL']
-    ];
+        'url' => isset($uploadResult['fileURL']) ? $uploadResult['fileURL'] : null,
+    ];    
+
+    // Export locally
+    if ($envType === 'local') {
+        $file_path = "output/$feedID.json";
+        
+        // Use file_put_contents to save the content to the local file
+        $result = file_put_contents($file_path, file_get_contents($file_path));
+
+        if ($result !== false) {
+            echo "Feed data successfully written to the file. $result bytes written.";
+        } else {
+            echo "Error writing data to local file.";
+        }
+    }
+
+    if ($envType !== 'local') {
+        // Export to s3
+        $uploadResult = uploadFiletoS3($s3Client, $s3BucketName, $s3BucketPath . "$feedID.json", $jsonFile);
+
+        if (!$uploadResult['success'] || empty($uploadResult['fileURL'])) {
+            continue;
+        } 
+    }
 }
 
 //Create Available Feeds JSON File
-
 $feedsJSON = json_encode($availableFeeds);
 
 if (!$feedsJSON) {
-    return;
+    exit;
 }
 
 $writeFileResult = file_put_contents("output/feeds.json", $feedsJSON);
 
 if ($writeFileResult === false) {
-    return;
+    exit;
 }
 
-#$result = uploadFiletoS3($s3Client, $s3BucketName, $s3BucketPath . "feeds.json", "output/feeds.json");
+if ($envType == 'local') {
+    exit;
+}
 
-// function uploadFiletoS3($s3Client, $s3BucketName, $s3ObjectKey, $sourceFile)
-// {
+$result = uploadFiletoS3($s3Client, $s3BucketName, $s3BucketPath . "feeds.json", "output/feeds.json");
 
-//     return;
+function uploadFiletoS3($s3Client, $s3BucketName, $s3ObjectKey, $sourceFile)
+{
 
-//     $uploadResult = [
-//         "success" => false,
-//         "fileURL" => false
-//     ];
+    $uploadResult = [
+        "success" => false, 
+        "fileURL" => false
+    ];
 
-//     $result = [];
-//      // Upload to AWS s3 bucket
-//     try {
-//         // Upload the file to S3 bucket
-//         $result = $s3Client->putObject([
-//            'Bucket' => $s3BucketName,
-//            'Key' => $s3ObjectKey,
-//            'ACL' => 'public-read',
-//            'SourceFile' => '/' . $sourceFile
-//         ]) 
+    $result = [];
+     // Upload to AWS s3 bucket
+    try {
+        // Upload the file to S3 bucket
+        $result = $s3Client->putObject([
+           'Bucket' => $s3BucketName,
+           'Key' => $s3ObjectKey,
+           'ACL' => 'public-read',
+           'SourceFile' => '/' . $sourceFile
+        ]);
 
-//         $uploadResult['success'] = true;
+        $uploadResult['success'] = true;
 
-//         $uploadedFileName = basename('/' . $sourceFile);
-//         echo "File '$uploadedFileName' uploaded to S3 successfully." . PHP_EOL;
-//     } catch (AwsException $e) {
-//         echo 'Error: ' . $e->getMessage() . PHP_EOL;
-//     }
+        $uploadedFileName = basename('/' . $sourceFile);
+        echo "File '$uploadedFileName' uploaded to S3 successfully." . PHP_EOL;
+    } catch (AwsException $e) {
+        echo 'Error: ' . $e->getMessage() . PHP_EOL;
+    }
 
-//     if (!empty($result) && array_key_exists('effectiveUri', $result['@metadata'])) {
-//         $uploadResult['fileURL'] = $result['@metadata']['effectiveUri'];
-//     }
+    if(!empty($result) && array_key_exists('effectiveUri', $result['@metadata'])){
+        
+        $uploadResult['fileURL'] = $result['@metadata']['effectiveUri'];      
+    }
 
-//     return $uploadResult;
-// }
+    return $uploadResult;
+}

--- a/run.php
+++ b/run.php
@@ -120,12 +120,12 @@ foreach ($feeds as $feed) {
     $availableFeeds[] = [
         'name' => $feed['name'],
         'url' => isset($uploadResult['fileURL']) ? $uploadResult['fileURL'] : null,
-    ];    
+    ];
 
     // Export locally
     if ($envType === 'local') {
         $file_path = "output/$feedID.json";
-        
+
         // Use file_put_contents to save the content to the local file
         $result = file_put_contents($file_path, file_get_contents($file_path));
 
@@ -142,7 +142,7 @@ foreach ($feeds as $feed) {
 
         if (!$uploadResult['success'] || empty($uploadResult['fileURL'])) {
             continue;
-        } 
+        }
     }
 }
 
@@ -169,7 +169,7 @@ function uploadFiletoS3($s3Client, $s3BucketName, $s3ObjectKey, $sourceFile)
 {
 
     $uploadResult = [
-        "success" => false, 
+        "success" => false,
         "fileURL" => false
     ];
 
@@ -181,7 +181,7 @@ function uploadFiletoS3($s3Client, $s3BucketName, $s3ObjectKey, $sourceFile)
            'Bucket' => $s3BucketName,
            'Key' => $s3ObjectKey,
            'ACL' => 'public-read',
-           'SourceFile' => '/' . $sourceFile
+           'SourceFile' => '/' . $sourceFile . 'test'
         ]);
 
         $uploadResult['success'] = true;
@@ -192,9 +192,8 @@ function uploadFiletoS3($s3Client, $s3BucketName, $s3ObjectKey, $sourceFile)
         echo 'Error: ' . $e->getMessage() . PHP_EOL;
     }
 
-    if(!empty($result) && array_key_exists('effectiveUri', $result['@metadata'])){
-        
-        $uploadResult['fileURL'] = $result['@metadata']['effectiveUri'];      
+    if (!empty($result) && array_key_exists('effectiveUri', $result['@metadata'])) {
+        $uploadResult['fileURL'] = $result['@metadata']['effectiveUri'];
     }
 
     return $uploadResult;

--- a/run.php
+++ b/run.php
@@ -41,26 +41,26 @@ $feeds = [
     ],
  ];
 
-if (count($feeds) == 0) {
-    return;
-}
+// if (count($feeds) == 0) {
+//     return;
+// }
 
-$availableFeeds = [];
+// $availableFeeds = [];
 
- // AWS S3 Bucket Name
-$s3BucketName = getenv('S3_UPLOADS_BUCKET');
+//  // AWS S3 Bucket Name
+// $s3BucketName = getenv('S3_UPLOADS_BUCKET');
 
-// AWS S3 Bucket Path
-$s3BucketPath = 'feed-parser/';  // Set to an empty string if the root of the bucket
+// // AWS S3 Bucket Path
+// $s3BucketPath = 'feed-parser/';  // Set to an empty string if the root of the bucket
 
-// AWS S3 Region
-$awsRegion = 'eu-west-2';
+// // AWS S3 Region
+// $awsRegion = 'eu-west-2';
 
-// Create an S3Client with the AWS credentials automatically provided by IAM instance profile
-$s3Client = new S3Client([
-    'region' => $awsRegion,
-    'version' => 'latest'
-]);
+// // Create an S3Client with the AWS credentials automatically provided by IAM instance profile
+// $s3Client = new S3Client([
+//     'region' => $awsRegion,
+//     'version' => 'latest'
+// ]);
 
 
 foreach ($feeds as $feed) {
@@ -89,7 +89,7 @@ foreach ($feeds as $feed) {
 
     $filters = [];
 
-    if(array_key_exists('filters', $feed) && !empty($feed['filters'])){
+    if (array_key_exists('filters', $feed) && !empty($feed['filters'])) {
         $filters = $feed['filters'];
     }
 
@@ -101,17 +101,21 @@ foreach ($feeds as $feed) {
         continue;
     }
 
-    $uploadResult = uploadFiletoS3($s3Client, $s3BucketName, $s3BucketPath . "$feedID.json", $jsonFile);
+    #$uploadResult = uploadFiletoS3($s3Client, $s3BucketName, $s3BucketPath . "$feedID.json", $jsonFile);
 
-    if (!$uploadResult['success'] || empty($uploadResult['fileURL'])) {
-        continue;
-    }
+    $file_path = "output/$feedID.json";
+
+    // Use file_put_contents to save the content to the local file
+    $result = file_put_contents($file_path, $jsonFile);
+
+    // if (!$uploadResult['success'] || empty($uploadResult['fileURL'])) {
+    //     continue;
+    // }
 
     $availableFeeds[] = [
         'name' => $feed['name'],
-        'url' => $uploadResult['fileURL']
+        // 'url' => $uploadResult['fileURL']
     ];
-    
 }
 
 //Create Available Feeds JSON File
@@ -128,39 +132,40 @@ if ($writeFileResult === false) {
     return;
 }
 
-$result = uploadFiletoS3($s3Client, $s3BucketName, $s3BucketPath . "feeds.json", "output/feeds.json");
+#$result = uploadFiletoS3($s3Client, $s3BucketName, $s3BucketPath . "feeds.json", "output/feeds.json");
 
-function uploadFiletoS3($s3Client, $s3BucketName, $s3ObjectKey, $sourceFile)
-{
+// function uploadFiletoS3($s3Client, $s3BucketName, $s3ObjectKey, $sourceFile)
+// {
 
-    $uploadResult = [
-        "success" => false, 
-        "fileURL" => false
-    ];
+//     return;
 
-    $result = [];
-     // Upload to AWS s3 bucket
-    try {
-        // Upload the file to S3 bucket
-        $result = $s3Client->putObject([
-           'Bucket' => $s3BucketName,
-           'Key' => $s3ObjectKey,
-           'ACL' => 'public-read',
-           'SourceFile' => '/' . $sourceFile
-        ]);
+//     $uploadResult = [
+//         "success" => false,
+//         "fileURL" => false
+//     ];
 
-        $uploadResult['success'] = true;
+//     $result = [];
+//      // Upload to AWS s3 bucket
+//     try {
+//         // Upload the file to S3 bucket
+//         $result = $s3Client->putObject([
+//            'Bucket' => $s3BucketName,
+//            'Key' => $s3ObjectKey,
+//            'ACL' => 'public-read',
+//            'SourceFile' => '/' . $sourceFile
+//         ]) 
 
-        $uploadedFileName = basename('/' . $sourceFile);
-        echo "File '$uploadedFileName' uploaded to S3 successfully." . PHP_EOL;
-    } catch (AwsException $e) {
-        echo 'Error: ' . $e->getMessage() . PHP_EOL;
-    }
+//         $uploadResult['success'] = true;
 
-    if(!empty($result) && array_key_exists('effectiveUri', $result['@metadata'])){
-        
-        $uploadResult['fileURL'] = $result['@metadata']['effectiveUri'];      
-    }
+//         $uploadedFileName = basename('/' . $sourceFile);
+//         echo "File '$uploadedFileName' uploaded to S3 successfully." . PHP_EOL;
+//     } catch (AwsException $e) {
+//         echo 'Error: ' . $e->getMessage() . PHP_EOL;
+//     }
 
-    return $uploadResult;
-}
+//     if (!empty($result) && array_key_exists('effectiveUri', $result['@metadata'])) {
+//         $uploadResult['fileURL'] = $result['@metadata']['effectiveUri'];
+//     }
+
+//     return $uploadResult;
+// }

--- a/run.php
+++ b/run.php
@@ -181,7 +181,7 @@ function uploadFiletoS3($s3Client, $s3BucketName, $s3ObjectKey, $sourceFile)
            'Bucket' => $s3BucketName,
            'Key' => $s3ObjectKey,
            'ACL' => 'public-read',
-           'SourceFile' => '/' . $sourceFile . 'test'
+           'SourceFile' => '/' . $sourceFile
         ]);
 
         $uploadResult['success'] = true;


### PR DESCRIPTION
Currently some role types are “missing” from the Oleeo feed. This is due to limited role type options in the Oleeo dashboard when editors are entering in jobs. To get around this editors are putting these ‘extra’ role types into the job title. We need to add into the parser a function that pulls out these additional role types from the title and appends them into our json feed in the field of “role type”.

The additional role types we want to appear in the role filter are:
Prison Catering
Case Administrator
Community Payback
Youth Justice Worker

This adds in these types. 

Local development

Changes made here allow us to run the app locally for debugging and development.